### PR TITLE
Fixing radius server command changed in new firmware

### DIFF
--- a/access/tasks/main.yml
+++ b/access/tasks/main.yml
@@ -10,14 +10,12 @@
 
   - name: Setup dhcp snooping
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - ip dhcp snooping vlan 500-2000
           - ip dhcp snooping
 
   - name: Setup local ports
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - switchport mode access
           - spanning-tree portfast
@@ -32,7 +30,6 @@
   - name: Setup local ports (RADIUS)
     when: polynet_access_enable_radius_mab
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - authentication order mab
           - authentication priority mab
@@ -47,20 +44,18 @@
 
   - name: Setup trunk ports
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
-          - switchport mode trunk
           - ip dhcp snooping trust
           - switchport trunk encapsulation dot1q
+          - switchport mode trunk
           - switchport trunk allowed {{ global_vlans }}
         parents:  interface {{ item }}
     with_items: "{{ trunk_range }}"
 
   - name: Setup wan vlan
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - name WAN
         parents:  vlan {{ wan_vlan.number }}
@@ -68,14 +63,12 @@
 
   - name: disable stp for wan vlan
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree vlan {{ wan_vlan.number }}
     when: access_vlan.border_switch is defined and access_vlan.border_switch
 
   - name: Setup port channel - border
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
@@ -87,7 +80,6 @@
 
   - name: Setup misc po ports - border
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
@@ -101,13 +93,12 @@
 
   - name: Setup misc po ports - trunk
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
-          - switchport mode trunk
           - ip dhcp snooping trust
           - switchport trunk encapsulation dot1q
+          - switchport mode trunk
           - switchport trunk allowed {{ global_vlans }}
         parents:  interface {{ item }}
     with_items: "{{ misc_po_range }}"
@@ -115,7 +106,6 @@
 
   - name: Setup misc ports - border
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
@@ -128,13 +118,12 @@
 
   - name: Setup misc ports - trunk
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - no spanning-tree portfast
           - no spanning-tree bpduguard enable
-          - switchport mode trunk
           - ip dhcp snooping trust
           - switchport trunk encapsulation dot1q
+          - switchport mode trunk
           - switchport trunk allowed {{ global_vlans }}
         parents:  interface {{ item }}
     with_items: "{{ misc_range }}"
@@ -142,7 +131,6 @@
 
   - name: Setup core VLAN Interface
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - description interconnect vlan
         - ip address {{ access_vlan.core_ip }} 255.255.255.0
@@ -150,7 +138,6 @@
 
   - name: Setup access VLAN Interface
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - description {{ access_vlan.description }} vlan
         - ip address {{ access_vlan.ip }} 255.255.255.0
@@ -160,7 +147,6 @@
 
   - name: Setup WAN VLAN Interface
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - description wan vlan
         - ip address {{ access_vlan.wan_ip }} 255.255.255.0
@@ -169,13 +155,11 @@
 
   - name: Enable ip routing
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - ip routing
 
   - name: Setup ospf core
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - log-adjacency-changes
         - network {{ vlans['core'].subnet }} area 0.0.0.0
@@ -183,14 +167,12 @@
 
   - name: Setup ospf access
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - network {{ access_vlan.subnet }} area 0.0.0.0
       parents: router ospf 1
 
   - name: Setup ospf wan
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - network {{ wan_vlan.subnet }} area 0.0.0.0
       parents: router ospf 1

--- a/base/defaults/main.yml
+++ b/base/defaults/main.yml
@@ -2,7 +2,6 @@ snmp_ro_string: "public"
 
 polynet_base_enable_radius: False
 polynet_base_radius_servers: []
-polynet_base_radius_server_secret: ""
 polynet_base_enable_radius_coa: False
 polynet_base_radius_coa_clients: []
 #  - ip:

--- a/base/tasks/main.yml
+++ b/base/tasks/main.yml
@@ -65,7 +65,9 @@
     ios_config:
       provider: "{{ provider }}"
       lines:
-        - radius-server host {{ item }} auth-port 1812 acct-port 1813
+        - address ipv4 {{ item.ip }} auth-port 1812 acct-port 1813
+        - key {{ item.secret }}
+      parents: radius server {{ item.name }}
     with_items: "{{ polynet_base_radius_servers }}"
     tags:
       - radius
@@ -75,7 +77,6 @@
     ios_config:
       provider: "{{ provider }}"
       lines:
-        - radius-server key {{ polynet_base_radius_server_secret }}
         - radius-server vsa send authentication
         - radius-server retransmit 2
         - radius-server timeout 3

--- a/base/tasks/main.yml
+++ b/base/tasks/main.yml
@@ -12,25 +12,21 @@
 
   - name: Setup hostname
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - hostname {{ inventory_hostname }}
 
   - name: Enable snmp
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - snmp-server community {{ snmp_ro_string }} RO
 
   - name: Disable vtp
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - vtp mode off
 
   - name: Setup vlans
     ios_config:
-        provider: "{{ provider }}"
         lines:
           - name {{ item.value.description}}
         parents:  vlan {{ item.value.number }}
@@ -38,16 +34,14 @@
 
   - name: Setup mgmnt VLAN Interface
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - description mgmnt vlan
         - ip address {{ ansible_host }} 255.255.255.0
-      parents: interface vlan 1
+      parents: interface Vlan1
 
   - name: Enable AAA for Radius
     when: polynet_base_enable_radius
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - aaa new-model
         - aaa authentication dot1x default group radius
@@ -63,7 +57,6 @@
   - name: Setup RADIUS servers
     when: polynet_base_enable_radius
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - address ipv4 {{ item.ip }} auth-port 1812 acct-port 1813
         - key {{ item.secret }}
@@ -75,7 +68,6 @@
   - name: Setup RADIUS settings
     when: polynet_base_enable_radius
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - radius-server vsa send authentication
         - radius-server retransmit 2
@@ -91,7 +83,6 @@
   - name: Setup RADIUS CoA server clients
     when: polynet_base_enable_radius_coa
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - client {{ item.ip }} server-key {{ item.secret }}
       parents: aaa server radius dynamic-author
@@ -102,7 +93,6 @@
   - name: Setup RADIUS CoA server settings
     when: polynet_base_enable_radius_coa
     ios_config:
-      provider: "{{ provider }}"
       lines:
         - port 3799
       parents: aaa server radius dynamic-author


### PR DESCRIPTION
The new firmware deprecated the old way to set up radius servers. 
This pull request also requires a config change in the group vars.